### PR TITLE
Fix fatal error for custom request methods

### DIFF
--- a/src/Weebly/WeeblyClient.php
+++ b/src/Weebly/WeeblyClient.php
@@ -242,7 +242,7 @@ class WeeblyClient
             );
         } else if ($method !== 'GET'){
             $options = array(
-                CURLOPT_CUSTOMREQUEST, $method,
+                CURLOPT_CUSTOMREQUEST => $method,
                 CURLOPT_POSTFIELDS => json_encode($parameters)
             );
         }


### PR DESCRIPTION
@tjsnyder This fixes a fatal error for custom request methods (that aren't `POST` or `GET`). 