### PR TITLE
Set access token when receive new + fix error

### DIFF
--- a/src/Weebly/WeeblyClient.php
+++ b/src/Weebly/WeeblyClient.php
@@ -216,7 +216,10 @@ class WeeblyClient
         }
 
         $result = $this->makeRequest($url, $this->prepareAccessTokenParams($authorization_code));
-        return $result->access_token;
+        
+        $this->access_token = (isset($result->access_token)) ? $result->access_token : null;
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Set access token when receive new one + fix error when wrong auth_code and `$result->access_token` didn't exist.